### PR TITLE
PENDINGUPSTREAM: Handle NO_DOMAIN status

### DIFF
--- a/designate/central/service.py
+++ b/designate/central/service.py
@@ -2348,6 +2348,15 @@ class Service(service.RPCService, service.Service):
                     and (serial >= domain_or_record.serial or serial == 0):
                 domain_or_record.status = 'ERROR'
 
+        elif status == 'NO_DOMAIN':
+            if domain_or_record.action in ['CREATE', 'UPDATE']:
+                domain_or_record.action = 'CREATE'
+                domain_or_record.status = 'ERROR'
+            elif domain_or_record.action == 'DELETE':
+                domain_or_record.action = 'NONE'
+                domain_or_record.status = 'DELETED'
+                deleted = True
+
         return domain_or_record, deleted
 
     # Zone Transfers

--- a/designate/pool_manager/service.py
+++ b/designate/pool_manager/service.py
@@ -499,6 +499,12 @@ class Service(service.RPCService, coordination.CoordinationMixin,
                     self.central_api.update_status(
                         context, domain.id, ERROR_STATUS, error_serial)
 
+            if status == NO_DOMAIN_STATUS and action != DELETE_ACTION:
+                LOG.warn(_LW('Domain %(domain)s is not present in some '
+                             'targets') % {'domain': domain.name})
+                self.central_api.update_status(
+                    context, domain.id, NO_DOMAIN_STATUS, 0)
+
             if consensus_serial == domain.serial and self._is_consensus(
                     context, domain, action, SUCCESS_STATUS,
                     MAXIMUM_THRESHOLD):
@@ -638,8 +644,8 @@ class Service(service.RPCService, coordination.CoordinationMixin,
                 pool_manager_status.status = 'ERROR'
             elif action == DELETE_ACTION:
                 pool_manager_status.status = 'SUCCESS'
-            # TODO(Ron): Handle this case properly.
             elif action == UPDATE_ACTION:
+                pool_manager_status.action = 'CREATE'
                 pool_manager_status.status = 'ERROR'
         else:
             pool_manager_status.status = status


### PR DESCRIPTION
https://review.openstack.org/#/c/230770/2

Previous to this patch, when MiniDNS got a `NO_DOMAIN` status back,
it didn't do anything to handle it. Domains just hung in ERROR.

closes-bug: #1416264
Change-Id: I4348f714868f38c2549c516fe83cce608c0c8d59