### PR TITLE
HACK: Designate puts tenant IDs in the URL

### DIFF
--- a/designate/api/__init__.py
+++ b/designate/api/__init__.py
@@ -27,6 +27,8 @@ cfg.CONF.register_opts([
                help='Number of api greenthreads to spawn'),
     cfg.BoolOpt('enable-host-header', default=False,
                help='Enable host request headers'),
+    cfg.BoolOpt('enable-tenant-id-in-url', default=True,
+               help='Put the tenant id in self links'),
     cfg.StrOpt('api-base-uri', default='http://127.0.0.1:9001/'),
     cfg.StrOpt('api_host', default='0.0.0.0',
                help='API Host'),

--- a/designate/objects/adapters/api_v2/zone_export.py
+++ b/designate/objects/adapters/api_v2/zone_export.py
@@ -56,14 +56,14 @@ class ZoneExportAPIv2Adapter(base.APIv2Adapter):
         obj = super(ZoneExportAPIv2Adapter, cls)._render_object(
             object, *args, **kwargs)
 
-        if obj['location'] and obj['location'].startswith('designate://'):
+        if obj['location'] and object['location'].startswith('designate://'):
             # Get the base uri from the self link, which respects host headers
             base_uri = obj['links']['self']. \
                 split(cls._get_path(kwargs['request']))[0]
 
             obj['links']['export'] = \
                 '%s/%s' % \
-                (base_uri, obj['location'].split('://')[1])
+                (base_uri, 'export')
 
         return obj
 

--- a/etc/designate/designate.conf.sample
+++ b/etc/designate/designate.conf.sample
@@ -87,6 +87,9 @@ debug = False
 # Enable host request headers
 #enable_host_header = False
 
+# Put the tenant id in self links
+#enable_tenant_id_in_url = True
+
 # The base uri used in responses
 #api_base_uri = 'http://127.0.0.1:9001/'
 


### PR DESCRIPTION
- Puts tenant IDs in the url in the right place for our deployment
  ex: `v2/tenantid/zones`

Also fixes self links in zone exports

```
GET http://designate.timsimmons.me/v2/zones
{
    "zones": [
        {
            "status": "ACTIVE",
            "masters": [],
            "name": "example1.com.",
            "links": {
                "self": "http://designate.timsimmons.me/v2/noauth-project/zones/22eb7d9a-e588-4108-9529-7d3bfaed77ff"
            },
....
    ],
    "links": {
        "self": "http://designate.timsimmons.me/v2/noauth-project/zones",
        "next": "http://designate.timsimmons.me/v2/noauth-project/zones?marker=1b4de6fd-aa08-4eb9-bfac-342e1b36a38a"
    },
    "metadata": {
        "total_count": 20
    }
}

GET http://designate.timsimmons.me/v2/zones/tasks/exports/0925488a-4000-445f-8013-8c571b9ee1b4/
{
    "status": "COMPLETE",
    "zone_id": "22eb7d9a-e588-4108-9529-7d3bfaed77ff",
    "links": {
        "self": "http://designate.timsimmons.me/v2/noauth-project/zones/tasks/exports/0925488a-4000-445f-8013-8c571b9ee1b4",
        "export": "http://designate.timsimmons.me/v2/noauth-project/zones/tasks/exports/0925488a-4000-445f-8013-8c571b9ee1b4/export"
    },
    "created_at": "2015-11-11T22:42:12.000000",
    "updated_at": "2015-11-11T22:42:12.000000",
    "version": 2,
    "location": "designate://v2/zones/tasks/exports/0925488a-4000-445f-8013-8c571b9ee1b4/export",
    "message": null,
    "project_id": "noauth-project",
    "id": "0925488a-4000-445f-8013-8c571b9ee1b4"
}